### PR TITLE
Hotfix/deployment

### DIFF
--- a/.github/workflows/api_image.yml
+++ b/.github/workflows/api_image.yml
@@ -22,4 +22,4 @@ jobs:
           context: .
           file: ./app/api/Dockerfile
           push: true
-          tags: ${{ secrets.SEB_DOCKERHUB_USERNAME }}/umap-api:v0.2.0
+          tags: ${{ secrets.SEB_DOCKERHUB_USERNAME }}/umap-api:v0.2.1

--- a/.github/workflows/streamlit.yml
+++ b/.github/workflows/streamlit.yml
@@ -22,4 +22,4 @@ jobs:
           context: .
           file: ./app/streamlit/Dockerfile
           push: true
-          tags: ${{ secrets.SEB_DOCKERHUB_USERNAME }}/umap-streamlit:v0.2.0
+          tags: ${{ secrets.SEB_DOCKERHUB_USERNAME }}/umap-streamlit:v0.2.1

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -21,7 +21,8 @@ Another Docker image is required for the Streamlit front-end.
 
 # Continuous Deployment
 
-- Deployment is handled by ArgoCD based on the `https://github.com/victorgalmiche/umap-deployment` repository
-- configuration is in `deployment`. The API is deployed to `https://umap-api-mmvs.lab.sspcloud.fr`
+- Deployment is handled by ArgoCD based on the `https://github.com/victorgalmiche/umap-deployment` repository. Configuration is in `deployment`. 
+- The backend API is deployed to `https://umap-api-mmvs.lab.sspcloud.fr`
+- The front-end streamlit API is deployed to `https://umap-streamlit-mmvs.lab.sspcloud.fr`
 - ArgoCD detects pushes to this repository, and updates the deployment.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Aka how to test the app without making noisy commits to the main branch. A propo
 - create a pull request. Note that a temporary pull request can be created on Github.
 - bump tags for the Docker images
 - you can still make changes after tagging the Docker images, until these are pulled / deployed, cf below.
+- merge the pull request (this triggers a push to DockerHub)
 
 # Developper updates the Deployment repo
 
@@ -31,6 +32,7 @@ Aka how to test the app without making noisy commits to the main branch. A propo
 
 _Why this is necessary_ : ArgoCD pulls from DockerHub, but only once for each tag. This is a Kubernetes default config: the image is pulled IfNotPresent.
 Consequently, you need to modify the image tag in `deployment.yaml` to pull an updated Docker image.
+Therefore there is a small uncertainty in the exact version that is deployed. A SHA digest can be used to fix the exact version of the Docker image.
 
 Note : two alternatives. 1) If the image tag is not specified or is set to latest, the pull policiy defaults to Always. 2) An ArgoCD image updater resource (an additional pod)can detect updates to DockerHub. It does so by making commits to the deployment repository
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# How to develop in the context of an automatically deployed application
+
+Aka how to test the app without making noisy commits to the main branch. A proposal follows.
+
+# Create a new branch
+
+- git branch
+- git checkout
+
+# Develop inside the new branch
+
+- **local test** : `uv run uvicorn`. This works because a proxy system is in place on onyxia and the service / port is reachable in a web browser
+- git commit
+- git push
+- CI process builds the Docker image and pushes it to **Docker Hub**, even for test branches. 
+- Deployment is not affected because it uses hard-coded tags.
+- **test in Docker** : `kubectl run -it api-ml --image=your_image` can be used to test image.
+
+# When ready to merge
+
+- create a pull request. Note that a temporary pull request can be created on Github.
+- bump tags for the Docker images
+
+# Developper updates the Deployment repo
+
+- Developper manually updates the tags in the deployment repository.
+- Argo CD detects changes in the deployment configuration
+- Argo CD pulls the new Docker image into onyxia
+- Kubernetes deploys the application into multiple Pods
+
+_Why this is necessary_ : ArgoCD pulls from DockerHub, but only once for each tag. This is a Kubernetes default config: the image is pulled IfNotPresent.
+Consequently, you need to modify the image tag in `deployment.yaml` to pull an updated Docker image.
+
+Note : two alternatives. 1) If the image tag is not specified or is set to latest, the pull policiy defaults to Always. 2) An ArgoCD image updater resource (an additional pod)can detect updates to DockerHub. It does so by making commits to the deployment repository
+
+How to test changes to the deployment repo without committing to main ?
+- solution 1: test in a different namespace
+- solution 2: use another ArgoCD application to track a `dev` branch
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Aka how to test the app without making noisy commits to the main branch. A propo
 
 - create a pull request. Note that a temporary pull request can be created on Github.
 - bump tags for the Docker images
+- you can still make changes after tagging the Docker images, until these are pulled / deployed, cf below.
 
 # Developper updates the Deployment repo
 


### PR DESCRIPTION
## Briefly describe the changes
- [x] fixed : `run.sh` must have exec permissions
- [x] bump Docker images to versions 0.2.1 to force ArgoCD to pull / deploy the new images
- [x] document deployment architecture
- [x] propose a contributing procedure, highlight when and how to test
