### PR TITLE
Hotfix/sequential workflow

### DIFF
--- a/.github/workflows/api_image.yml
+++ b/.github/workflows/api_image.yml
@@ -1,10 +1,13 @@
 name: api-ci
 
 on:
-  push:
+  workflow_run:
+    workflows: ["tests"]   
+    types: [completed]
 
 jobs:
   docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,56 @@
+name: linters
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # latest python minor
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          
+      - name: Install dev dependencies
+        run: |
+          uv sync
+      
+      - name: ruff formatting
+        run : |
+          uv run ruff format src/
+
+      - name: Commit and push formatted code
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Autoformat with Ruff"
+          git push origin HEAD:${{ github.head_ref }}
+
+      - name: pylint report
+        run: uv run pylint src
+        continue-on-error: true
+
+      - name: Upload recording.log artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: log-file
+          path: recording.log
+          if-no-files-found: warn

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 jobs:
-  test:
+  linting:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -46,7 +46,8 @@ jobs:
 
       - name: pylint report
         run: uv run pylint src > pylint-report.txt
-        
+        continue-on-error: true
+
       - name: Upload rpylint-report.txt artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -45,12 +45,13 @@ jobs:
           git push origin HEAD:${{ github.head_ref }}
 
       - name: pylint report
-        run: uv run pylint src
-        continue-on-error: true
-
-      - name: Upload recording.log artifact
+        run: uv run pylint src > pylint-report.txt
+        
+      - name: Upload rpylint-report.txt artifact
         uses: actions/upload-artifact@v4
         with:
-          name: log-file
-          path: recording.log
+          name: pylint-report-file
+          path: pylint-report.txt
           if-no-files-found: warn
+
+      

--- a/.github/workflows/streamlit.yml
+++ b/.github/workflows/streamlit.yml
@@ -1,10 +1,13 @@
 name: streamlit-ci
 
 on:
-  push:
+  workflow_run:
+    workflows: ["tests"]   
+    types: [completed]
 
 jobs:
   docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,11 +1,7 @@
-name: PR Tests
+name: tests
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-permissions:
-  contents: write
+  push:
 
 jobs:
   test:
@@ -14,13 +10,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-
+        
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          # latest python minor
           python-version: '3.x'
 
       - name: Install dependencies
@@ -31,25 +24,8 @@ jobs:
       - name: Install dev dependencies
         run: |
           uv sync
-      
-      - name: ruff formatting
-        run : |
-          uv run ruff format src/
-
-      - name: Commit and push formatted code
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff-index --quiet HEAD || git commit -m "Autoformat with Ruff"
-          git push origin HEAD:${{ github.head_ref }}
-
-      - name: pylint report
-        run: uv run pylint src
-        continue-on-error: true
 
       - name: Run tests
-        # C'est ici que l'on injecte les secrets pour l'API
         env:
           MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
           MLFLOW_TRACKING_USERNAME: ${{ secrets.MLFLOW_TRACKING_USERNAME }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,10 +32,12 @@ jobs:
           MLFLOW_TRACKING_PASSWORD: ${{ secrets.MLFLOW_TRACKING_PASSWORD }}
           APP_ENV: test
         run: uv run pytest tests/
-
+      
       - name: Upload recording.log artifact
         uses: actions/upload-artifact@v4
         with:
           name: log-file
           path: recording.log
           if-no-files-found: warn
+
+      


### PR DESCRIPTION
## Briefly describe the changes

Make the workflows sequential. 

## Related Issue
Fixes #32 

## Checklist
- [x] separate listing and tests
- [x] the tests workflow is now triggered on push, while the listing workflow remains triggered on pull requests 
- [x] add an artefact for pylint report 

Remark : 

I cannot test this yet, as the changes need to be merged into main before they can be triggered after the tests succeed.

Another approach would be to trigger all workflows on push, as follows : 

name: CI

on:
  push:

jobs:
  tests:
    runs-on: ubuntu-latest
    steps:

  docker:
    needs: tests    # <-- attend la fin de tests avec succès
    runs-on: ubuntu-latest
    steps:

Dites moi ce que vous préférez ! 