### PR TITLE
Added embeddings to return for /train api

### DIFF
--- a/app/api/api.py
+++ b/app/api/api.py
@@ -203,7 +203,8 @@ async def train_model(
         "embedding_shape": Y.shape,
         "n_samples": n_samples,
         "n_features": n_features,
-        "message": "Model cached. Use the access_key for the /transform endpoint."
+        "message": "Model cached. Use the access_key for the /transform endpoint.",
+        "embedding": Y.tolist()
     }
 
 


### PR DESCRIPTION
## Briefly describe the changes

## Related Issue
Important fixes for training: return data that has been embed even for trianing

## Checklist
- [x] Added a field embedding with the corresponding list of embedding in the json output (same as /umap)

