### PR TITLE
Build image and push to DockerHub only on main branch

### DIFF
--- a/.github/workflows/api_image.yml
+++ b/.github/workflows/api_image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/streamlit.yml
+++ b/.github/workflows/streamlit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Current situation
linters are run on changes to PR
tests are run on each push (including to branches)
successful tests => build and push to DockerHub

# Target situation
successful tests after a push to the main branch only => build and push to DockerHub
