### PR TITLE
API: keep only numerical columns when importing CSV + doc updates

### DIFF
--- a/app/api/api.py
+++ b/app/api/api.py
@@ -106,13 +106,23 @@ def get_polars_from_request(content):
     """
     Get CSV data from the POST request
     Convert to a Polars dataframe
+    Keep only numerical columns
     raise exception if more than 500 lines (reason: limit compute ressources)
     """
 
-    df = pl.read_csv(io.BytesIO(content))
+    df = pl.read_csv(io.BytesIO(content)).select(pl.selectors.numeric())
 
     if df.height >= 500:
-        raise HTTPException(status_code=400, detail="CSV file must have less than 500 lines.")
+        raise HTTPException(
+            status_code=400,
+            detail="CSV file must have less than 500 lines (ressources limit)."
+            )
+
+    if df.width < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="CSV file must have at least 3 numerical columns."
+            )
 
     return df
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,6 +22,8 @@ As a first step :
 - limit request body to 2M and 500 lines. This translates to CSV files with no more than 500 lines (enforced in `app/api/api.py` and `app/streamlit/streamlit.py`) and 250 columns (deduced from 2M size limit)
 - limit rates to 1 request per second and 2 concurrent connections (in `ingress.yaml`), see [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rate-limiting)
 
+Also note that non-numerical columns are removed from the uploaded CSV.
+
 ---
 
 ## Running the App Locally

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,14 +16,14 @@ Aka how to test the app without making noisy commits to the main branch. A propo
 - Deployment is not affected because it uses hard-coded tags.
 - **test in Docker** : `kubectl run -it api-ml --image=your_image` can be used to test image.
 
-# When ready to merge
+# Get ready to merge
 
 - create a pull request. Note that a temporary pull request can be created on Github.
 - bump tags for the Docker images
 - you can still make changes after tagging the Docker images, until these are pulled / deployed, cf below.
 - merge the pull request (this triggers a push to DockerHub)
 
-# Developper updates the Deployment repo
+# Deploy by pushing to the Deployment repo
 
 - Developper manually updates the tags in the deployment repository.
 - Argo CD detects changes in the deployment configuration
@@ -32,7 +32,7 @@ Aka how to test the app without making noisy commits to the main branch. A propo
 
 _Why this is necessary_ : ArgoCD pulls from DockerHub, but only once for each tag. This is a Kubernetes default config: the image is pulled IfNotPresent.
 Consequently, you need to modify the image tag in `deployment.yaml` to pull an updated Docker image.
-Therefore there is a small uncertainty in the exact version that is deployed. A SHA digest can be used to fix the exact version of the Docker image.
+Therefore there is a small uncertainty in the exact version that is deployed. We use the SHA digest to fix the exact version of the Docker image. However, identifying the corresponding Github commit or tag is not trivial (this is on v2.0 todo list).
 
 Note : two alternatives. 1) If the image tag is not specified or is set to latest, the pull policiy defaults to Always. 2) An ArgoCD image updater resource (an additional pod)can detect updates to DockerHub. It does so by making commits to the deployment repository
 

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -16,7 +16,7 @@ All metrics are logged to **MLflow** under the `/monitoring/app-metrics` experim
 
 ### Middleware-Based Tracking
 
-A FastAPI middleware (`monitoring_middleware`) automatically tracks every request:
+A FastAPI middleware (`monitoring_middleware` in `app/api/api.py`) automatically tracks every request:
 - Measures latency for all endpoints
 - Logs HTTP status codes
 - Records success/failure status
@@ -124,82 +124,11 @@ Metrics logged:
 - Latency
 - Success/failure status
 
+
 ## Viewing Metrics
 
-### MLflow Dashboard
+Currently the metrics are logged to MLflow, but the existing dashboard graphs are not very useful.
 
-Access the MLflow dashboard at your configured `MLFLOW_TRACKING_URI`:
 
-```bash
-MLFLOW_TRACKING_URI=http://localhost:5000
-```
 
-Navigate to: `http://localhost:5000` → Experiments → `/monitoring/app-metrics`
 
-### Metric Examples
-
-**Average latency per endpoint:**
-```
-SELECT endpoint, AVG(latency_ms) FROM metrics GROUP BY endpoint
-```
-
-**Error rate per endpoint:**
-```
-SELECT endpoint, error_type, COUNT(*) FROM error_logs GROUP BY endpoint, error_type
-```
-
-**Cache utilization over time:**
-```
-SELECT timestamp, cached_models, cache_utilization_pct FROM metrics
-```
-
-## Best Practices
-
-### 1. Monitor Response Times
-
-Set alerts when latency exceeds thresholds:
-- 🟢 **Healthy**: < 2000 ms
-- 🟡 **Degraded**: 2000-5000 ms
-- 🔴 **Critical**: > 5000 ms
-
-### 2. Track Error Patterns
-
-Monitor error types to catch issues:
-- `invalid_csv_format` → data validation problem
-- `invalid_access_key` → user misuse or key expiration
-- `computation_error` → algorithm failure (should be rare with fallback)
-
-### 3. Cache Management
-
-Monitor cache growth:
-- If `cached_models` grows unbounded, consider implementing cache eviction
-- Current implementation: In-memory cache (lost on restart)
-- Watch `cache_utilization_pct` to plan capacity
-
-### 4. Alerting Rules
-
-**Recommended alerts:**
-```
-- latency_ms > 5000 for more than 5 requests
-- error_count > 10 per minute per endpoint
-- cached_models > 80 (nearing capacity)
-- critical: true errors (computation_error, timeout)
-```
-
-## Configuration
-
-Monitoring is automatically initialized when the API starts:
-
-```python
-monitor = get_monitor()
-```
-
-MLflow connection is configured via environment variables:
-
-```bash
-MLFLOW_TRACKING_URI=http://mlflow-server:5000
-MLFLOW_TRACKING_USERNAME=user
-MLFLOW_TRACKING_PASSWORD=password
-```
-
-The monitor will log an error and fail gracefully if MLflow is unavailable.


### PR DESCRIPTION
- API: keep only numerical columns when importing CSV, fixes #48 
- documentation updates 